### PR TITLE
Give "roles/billing.projectManager" on folders

### DIFF
--- a/google/README.md
+++ b/google/README.md
@@ -45,8 +45,9 @@ For each top-level lifecycle folder (`development` and `production`), the script
     *   `roles/resourcemanager.projectCreator`: Allows creation of new GCP projects within the `development` folder.
     *   `roles/resourcemanager.projectDeleter`: Allows deletion of GCP projects within the `development` folder.
     *   `roles/resourcemanager.projectIamAdmin`: Allows management of IAM policies on projects within the `development` folder.
+    *   `roles/billing.projectManager`: Allows management of the billing account attached to projects within `development` folder.
 *   **Permissions Granted on `production` folder**:
-    *   The same set of roles (`projectCreator`, `projectDeleter`, `projectIamAdmin`) are granted to the corresponding `production` service account on the `production` folder.
+    *   The same set of roles (`projectCreator`, `projectDeleter`, `projectIamAdmin`, `billing.projectManager`) are granted to the corresponding `production` service account on the `production` folder.
 
 ### 3. Billing Permissions
 

--- a/google/bin/config.sh
+++ b/google/bin/config.sh
@@ -155,6 +155,7 @@ function apply_stage_config() {
     _assign_folder_iam_role "${parent_folder_id}" "${service_account_email}" "roles/resourcemanager.projectCreator"
     _assign_folder_iam_role "${parent_folder_id}" "${service_account_email}" "roles/resourcemanager.projectDeleter"
     _assign_folder_iam_role "${parent_folder_id}" "${service_account_email}" "roles/resourcemanager.projectIamAdmin"
+    _assign_folder_iam_role "${parent_folder_id}" "${service_account_email}" "roles/billing.projectManager"
     _assign_billing_iam_role "${GCP_BILLING_ACCOUNT_ID}" "${service_account_email}"
 }
 


### PR DESCRIPTION
This ensures that the `cloudspace-creator` GSA will have permission to modify billing accounts on projects.

Role details: https://docs.cloud.google.com/billing/docs/how-to/billing-access#billing.projectManager